### PR TITLE
Remove Free List Usage

### DIFF
--- a/examples/simple_app/source/app.d
+++ b/examples/simple_app/source/app.d
@@ -56,7 +56,13 @@ string handler(HttpContext httpContext) @safe
 
     debug(Concurrency)
     {
+        import core.time : Duration, msecs;
         import vibe.core.core : sleep;
+
+        Duration randomDuration(int min = 50, int max = 150) @safe
+        {
+            return uniform(min, max).msecs;
+        }
 
         sleep(randomDuration);
     }
@@ -73,14 +79,4 @@ string randomString(uint length = 12) @safe
         result.put(charset[uniform(0, charset.length)]);
 
     return result.data;
-}
-
-debug(Concurrency)
-{
-    import core.time : Duration, msecs;
-
-    Duration randomDuration(int min = 50, int max = 150) @safe
-    {
-        return uniform(min, max).msecs;
-    }
 }


### PR DESCRIPTION
    Use standard GC allocation methods instead of
    a free list. Performance benchmarks via ab and
    profiling with Apple Instruments have not shown
    a reason to stick with a free list.