### PR TITLE
Add Ability to Route Requests to Handlers

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -9,11 +9,13 @@
 	"targetType": "library",
 	"dependencies": {
 		"eventcore": "~>0.9.34",
+		"pegged": "~>0.4.9",
 		"vibe-d:http": "~>0.10.1",
 	},
 	"dflags": [
 		"--preview=dip1000",
 	],
+	"sourceFolders": ["source/hutia_internal/"],
     "configurations": {
         "apple": {
             "platforms": [

--- a/dub.json
+++ b/dub.json
@@ -9,7 +9,6 @@
 	"targetType": "library",
 	"dependencies": {
 		"eventcore": "~>0.9.34",
-		"pegged": "~>0.4.9",
 		"vibe-d:http": "~>0.10.1",
 	},
 	"dflags": [

--- a/examples/simple_app/source/app.d
+++ b/examples/simple_app/source/app.d
@@ -1,4 +1,4 @@
-import hutia : HttpContext, logError, WebApplication;
+import hutia : HttpContext, logError, FromRoute, WebApplication;
 import std.array : Appender;
 import std.format : format;
 import std.random : uniform;
@@ -8,13 +8,32 @@ import vibe.stream.operations : readAllUTF8;
 int main(string[] args) @safe
 {
     auto app = WebApplication.create();
-    app.mapGet("/", &handler).withName("index");
-    app.mapGet("/test/", &handler).withName("no-route-values");
-    app.mapGet("/hello/<name>/<int:age>/", &handler).withName("route-values");
+    app.mapGet!simpleHandler("/");
+    app.mapGet!parameterBindingHandler("/parameter-binding/{name}/{age:int}/");
+    app.mapGet!useContextHandler("/use-context/");
     return app.run();
 }
 
-string handler(HttpContext httpContext) @safe
+string simpleHandler() @safe
+{
+    return "Hello, World!\n";
+}
+
+string parameterBindingHandler(
+    @FromRoute() string name,
+    @FromRoute("age") int ageInYears
+) @safe
+{
+    return (() @trusted => format(
+        "Received name of type `%s` with value '%s' and age of type `%s` with value '%s'!\n",
+        typeof(name).stringof,
+        name,
+        typeof(ageInYears).stringof,
+        ageInYears
+    ))();
+}
+
+string useContextHandler(HttpContext httpContext) @safe
 {
     auto httpRequest = httpContext.request;
 

--- a/examples/simple_app/source/app.d
+++ b/examples/simple_app/source/app.d
@@ -8,15 +8,12 @@ import vibe.stream.operations : readAllUTF8;
 int main(string[] args) @safe
 {
     auto app = WebApplication.create();
-    // map doesn't do any routing today and only supports setting a single handler app-wide.
-    return app
-           .map("", &handler)
-           .run();
+    app.mapGet("/", &handler).withName("index");
+    app.mapGet("/test/", &handler).withName("no-route-values");
+    app.mapGet("/hello/<name>/<int:age>/", &handler).withName("route-values");
+    return app.run();
 }
 
-// We need extern(C) here to satisfy an implementation detail of hutia's NGINX Unit
-// integration. In a future version this requirement won't be imposed on users.
-extern(C)
 string handler(HttpContext httpContext) @safe
 {
     auto httpRequest = httpContext.request;

--- a/examples/simple_app/source/app.d
+++ b/examples/simple_app/source/app.d
@@ -56,7 +56,13 @@ string handler(HttpContext httpContext) @safe
 
     debug(Concurrency)
     {
+        import core.time : Duration, msecs;
         import vibe.core.core : sleep;
+
+        Duration randomDuration(int min = 50, int max = 150) @safe
+        {
+            return uniform(min, max).msecs;
+        }
 
         sleep(randomDuration);
     }
@@ -73,14 +79,4 @@ string randomString(uint length = 12) @safe
         result.put(charset[uniform(0, charset.length)]);
 
     return result.data;
-}
-
-debug(Concurrency)
-{
-    import core.time : Duration, msecs;
-
-    Duration randomDuration(int min = 50, int max = 150) @safe
-    {
-        return uniform(min, max).msecs;
-    }
 }


### PR DESCRIPTION
    Port the routing engine from Potcake while making
    a few improvements. For example, we now use std.conv.to for
    conversions instead of path converters. We also improve routing 
    performance by switching from regex-based route matching to a 
    trie/regex hybrid. The hybrid setup reduces the number and 
    complexity of regex searches made and allowed for adding 
    compile-time regex compilation. Benchmarks show a 2.8% (1000 req/s) 
    increase in throughput when regex is involved.

    Add parameter binding from route values to prevent the need to
    manually extract and convert route values in handlers. Handlers look
    no different to non-handler functions apart from UDAs on parameters.
    
    Add graceful error handling of cases where developers
    use parameter binding in handlers for parameters that
    don't exist in route definitions.

    Ensure that exceptions are logged when they occur with
    context information from the request. Also ensure that
    requests that generate exceptions result in a 500
    response status code.